### PR TITLE
feat: Configure custom API key and update models

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -82,12 +82,38 @@ const MusicNoteIconSM: React.FC<{className?: string}> = ({className}) => (
 
 const App: React.FC = () => {
   const [selectedMapTypeForNewGame, setSelectedMapTypeForNewGame] = useState<MapType>(MapType.VOLGOGRAD_CAULDRON);
-  const [gameSettings, setGameSettings] = useState<GameSettings>(() => ({ // Initialize with a function to read from localStorage or default
-    isFoWEnabledForNewGame: true,
-    selectedGenAIModel: 'gemini-2.5-flash-preview-04-17',
-    isAggressiveSanitizationEnabled: false, 
-    isStructuredOutputEnabled: true,    
-  }));
+  const [gameSettings, setGameSettings] = useState<GameSettings>(() => {
+    const savedSettings = localStorage.getItem('gameSettings');
+    const defaults: GameSettings = {
+      isFoWEnabledForNewGame: true,
+      selectedGenAIModel: 'gemini-2.5-flash',
+      isAggressiveSanitizationEnabled: false,
+      isStructuredOutputEnabled: true,
+      apiKey: '',
+    };
+    if (savedSettings) {
+      return { ...defaults, ...JSON.parse(savedSettings) };
+    }
+    return defaults;
+  });
+
+  const [apiKeyInput, setApiKeyInput] = useState(gameSettings.apiKey || '');
+
+  useEffect(() => {
+    localStorage.setItem('gameSettings', JSON.stringify(gameSettings));
+  }, [gameSettings]);
+
+  const handleSaveApiKey = () => {
+    setGameSettings(prev => ({ ...prev, apiKey: apiKeyInput }));
+    alert('API Key saved!');
+  };
+
+  const handleClearApiKey = () => {
+    setApiKeyInput('');
+    setGameSettings(prev => ({ ...prev, apiKey: '' }));
+    alert('API Key cleared!');
+  };
+
   const [gameState, setGameState] = useState<GameState | null>(null);
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
   const [isSettingsModalOpen, setIsSettingsModalOpen] = useState(false);
@@ -615,10 +641,15 @@ const App: React.FC = () => {
               value={gameSettings.selectedGenAIModel}
               onChange={(e) => setGameSettings(prev => ({ ...prev, selectedGenAIModel: e.target.value }))}
             >
-              <option value="gemini-1.5-flash-latest">Gemini 1.5 Flash (Latest)</option>
-              <option value="gemini-1.5-pro-latest">Gemini 1.5 Pro (Latest)</option>
-              <option value="gemini-pro">Gemini Pro (Legacy)</option>
-              <option value="gemma-7b-it">Gemma 7B IT (Local)</option>
+              <option value="gemini-2.5-flash">gemini-2.5-flash (default)</option>
+              <option value="gemini-2.5-flash-lite">gemini-2.5-flash-lite</option>
+              <option value="gemini-2.5-pro">gemini-2.5-pro</option>
+              <option value="gemini-2.0-flash">gemini-2.0-flash</option>
+              <option value="gemma-3n-e2b-it">gemma-3n-e2b-it</option>
+              <option value="gemma-3n-e4b-it">gemma-3n-e4b-it</option>
+              <option value="gemma-3-4b-it">gemma-3-4b-it</option>
+              <option value="gemma-3-12b-it">gemma-3-12b-it</option>
+              <option value="gemma-3-27b-it">gemma-3-27b-it</option>
             </select>
           </div>
           <div className="mb-4 flex items-center">
@@ -647,6 +678,26 @@ const App: React.FC = () => {
           </div>
           <div className="flex items-center justify-between mt-4">
             <Button onClick={handleNewSetup} className="bg-blue-600 hover:bg-blue-700">Apply Settings & New Game</Button>
+          </div>
+          <div className="border-t border-gray-600 my-4 pt-4">
+            <h3 className="text-lg font-bold mb-2">Custom API Key</h3>
+            <div className="mb-4">
+              <label className="block text-sm font-bold mb-2" htmlFor="apiKey">
+                Gemini API Key (optional):
+              </label>
+              <input
+                type="password"
+                id="apiKey"
+                className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline bg-gray-700 border-gray-600"
+                placeholder="Enter your API key to override default"
+                value={apiKeyInput}
+                onChange={(e) => setApiKeyInput(e.target.value)}
+              />
+            </div>
+            <div className="flex items-center space-x-2">
+              <Button onClick={handleSaveApiKey} className="bg-green-600 hover:bg-green-700">Save Key</Button>
+              <Button onClick={handleClearApiKey} className="bg-red-600 hover:bg-red-700">Clear Key</Button>
+            </div>
           </div>
           <div className="mt-6">
             <h3 className="text-lg font-bold mb-2">Lyria Music Engine Settings</h3>

--- a/backend/src/game/phases.ts
+++ b/backend/src/game/phases.ts
@@ -38,7 +38,8 @@ export const handleFluctuationPhase = async (gameState: GameState, gameSettings:
             opponentLastSCSMessage, relevantHumanDirectiveForOpPlan, 
             gameSettings.isAggressiveSanitizationEnabled,
             gameSettings.isStructuredOutputEnabled,
-            isGemmaModelActive
+            isGemmaModelActive,
+            gameSettings.apiKey
         );
         
         if (plan) {
@@ -65,7 +66,7 @@ export const handleFluctuationPhase = async (gameState: GameState, gameSettings:
     const axiomGameStateSnapshot = newGameState;
     const axiomOpponentLastMsg = getOpponentLastMessage(AI2_ID, axiomGameStateSnapshot.commLog);
     const axiomHumanDirective = getLatestHumanDirectiveFor(AI2_ID, axiomGameStateSnapshot.commLog);
-    const axiomCommuniqueText = await generateStrategicCommunique(axiomGameStateSnapshot, AI2_ID, gameSettings.selectedGenAIModel, axiomOpponentLastMsg, axiomHumanDirective?.message || null);
+    const axiomCommuniqueText = await generateStrategicCommunique(axiomGameStateSnapshot, AI2_ID, gameSettings.selectedGenAIModel, axiomOpponentLastMsg, axiomHumanDirective?.message || null, gameSettings.apiKey);
     if (axiomCommuniqueText) {
         const axiomCommEntry: CommLogEntry = {
             id: `scs-${Date.now()}-axiom-${Math.random()}`, turn: axiomGameStateSnapshot.turn, timestamp: new Date().toLocaleTimeString(),
@@ -79,7 +80,7 @@ export const handleFluctuationPhase = async (gameState: GameState, gameSettings:
     const gemqGameStateSnapshot = {...newGameState, commLog: [...newGameState.commLog, ...newCommLogEntries]};
     const gemqOpponentLastMsg = getOpponentLastMessage(AI1_ID, gemqGameStateSnapshot.commLog);
     const gemqHumanDirective = getLatestHumanDirectiveFor(AI1_ID, gemqGameStateSnapshot.commLog);
-    const gemqCommuniqueText = await generateStrategicCommunique(gemqGameStateSnapshot, AI1_ID, gameSettings.selectedGenAIModel, gemqOpponentLastMsg, gemqHumanDirective?.message || null);
+    const gemqCommuniqueText = await generateStrategicCommunique(gemqGameStateSnapshot, AI1_ID, gameSettings.selectedGenAIModel, gemqOpponentLastMsg, gemqHumanDirective?.message || null, gameSettings.apiKey);
 
     if (gemqCommuniqueText) {
         const gemqCommEntry: CommLogEntry = {
@@ -123,7 +124,8 @@ export const handleManeuverPhase = async (factionId: PlayerId, gameState: GameSt
         gameSettings.selectedGenAIModel, 
         gameSettings.isAggressiveSanitizationEnabled,
         gameSettings.isStructuredOutputEnabled,
-        isGemmaModelActive
+        isGemmaModelActive,
+        gameSettings.apiKey
     );
 
     if (aiAction) {
@@ -873,7 +875,8 @@ export const handleDoctrinePhase = async (gameState: GameState, addLogEntry: any
             gameSettings.selectedGenAIModel,
             gameSettings.isAggressiveSanitizationEnabled,
             gameSettings.isStructuredOutputEnabled,
-            isGemmaModelActive
+            isGemmaModelActive,
+            gameSettings.apiKey
         );
 
         if (chosenDoctrineId) {

--- a/backend/src/services/geminiService.ts
+++ b/backend/src/services/geminiService.ts
@@ -23,17 +23,17 @@ import { isNodeVisibleForAI, isNodeConnectedToFactionCN } from "../game/utils";
 import { getMapData } from '../../data/mapData';
 
 const API_KEY = process.env.API_KEY;
-const DEFAULT_TEXT_MODEL = 'gemini-2.5-flash-preview-04-17';
+const DEFAULT_TEXT_MODEL = 'gemini-2.5-flash';
 const ALLOWED_TEXT_MODELS = [
-    DEFAULT_TEXT_MODEL,
     'gemini-2.5-flash',
-    'gemini-2.5-flash-lite-preview-06-17',
+    'gemini-2.5-flash-lite',
     'gemini-2.5-pro',
     'gemini-2.0-flash',
+    'gemma-3n-e2b-it',
     'gemma-3n-e4b-it',
-    'gemma-3-27b-it',
     'gemma-3-4b-it',
-    'gemma-3-12b-it'
+    'gemma-3-12b-it',
+    'gemma-3-27b-it'
 ];
 
 function minimalSanitizeAIJsonResponse(rawJsonText: string): string {
@@ -293,13 +293,15 @@ export const generateOpPlanFromGemini = async (
   humanDirective: CommLogEntry | null = null,
   isAggressiveSanitizationEnabled: boolean = true,
   isStructuredOutputEnabled: boolean = false,
-  isGemmaModel: boolean = false
+  isGemmaModel: boolean = false,
+  apiKey?: string
 ): Promise<OpPlan | null> => {
-  if (!API_KEY) {
+  const keyToUse = apiKey || API_KEY;
+  if (!keyToUse) {
     console.error("API_KEY not set for Gemini API.");
     return null;
   }
-  const ai = new GoogleGenAI({ apiKey: API_KEY });
+  const ai = new GoogleGenerativeAI(keyToUse);
   const selectedModel = ALLOWED_TEXT_MODELS.includes(modelName) ? modelName : DEFAULT_TEXT_MODEL;
 
   const simplifiedGameState = getSimplifiedGameStateForAI(currentGameState, factionId);
@@ -570,13 +572,15 @@ export const generateStrategicCommunique = async (
   factionId: PlayerId,
   modelName: string = DEFAULT_TEXT_MODEL,
   opponentLastMessage: CommLogEntry | null = null,
-  humanDirective: string | null = null 
+  humanDirective: string | null = null,
+  apiKey?: string
 ): Promise<string | null> => {
-  if (!API_KEY) {
+  const keyToUse = apiKey || API_KEY;
+  if (!keyToUse) {
     console.error("API_KEY not set for Gemini API (Strategic Communique).");
     return null;
   }
-  const ai = new GoogleGenAI({ apiKey: API_KEY });
+  const ai = new GoogleGenerativeAI(keyToUse);
   const selectedModel = ALLOWED_TEXT_MODELS.includes(modelName) ? modelName : DEFAULT_TEXT_MODEL;
 
   const faction = currentGameState.factions[factionId];
@@ -625,13 +629,15 @@ export const getAIActionFromGemini = async (
     modelName: string = DEFAULT_TEXT_MODEL,
     isAggressiveSanitizationEnabled: boolean = true,
     isStructuredOutputEnabled: boolean = false,
-    isGemmaModel: boolean = false
+    isGemmaModel: boolean = false,
+    apiKey?: string
 ): Promise<AIAction | null> => {
-    if (!API_KEY) {
+    const keyToUse = apiKey || API_KEY;
+    if (!keyToUse) {
         console.error("API_KEY not set for Gemini API.");
         return null;
     }
-    const ai = new GoogleGenAI({ apiKey: API_KEY });
+    const ai = new GoogleGenerativeAI(keyToUse);
     const selectedModel = ALLOWED_TEXT_MODELS.includes(modelName) ? modelName : DEFAULT_TEXT_MODEL;
 
     const simplifiedGameState = getSimplifiedGameStateForAI(currentGameState, factionId);
@@ -812,13 +818,15 @@ export const getAIFortifyActionFromGemini = async (
     modelName: string = DEFAULT_TEXT_MODEL,
     isAggressiveSanitizationEnabled: boolean = true,
     isStructuredOutputEnabled: boolean = false,
-    isGemmaModel: boolean = false
+    isGemmaModel: boolean = false,
+    apiKey?: string
 ): Promise<AIAction | null> => {
-    if (!API_KEY) {
+    const keyToUse = apiKey || API_KEY;
+    if (!keyToUse) {
         console.error("API_KEY not set for Gemini API for Fortify.");
         return null;
     }
-    const ai = new GoogleGenAI({ apiKey: API_KEY });
+    const ai = new GoogleGenerativeAI(keyToUse);
     const selectedModel = ALLOWED_TEXT_MODELS.includes(modelName) ? modelName : DEFAULT_TEXT_MODEL;
 
     const simplifiedGameState = getSimplifiedGameStateForAI(currentGameState, factionId);
@@ -947,13 +955,15 @@ export const chooseDoctrineFromGemini = async (
     modelName: string = DEFAULT_TEXT_MODEL,
     isAggressiveSanitizationEnabled: boolean = true,
     isStructuredOutputEnabled: boolean = false,
-    isGemmaModel: boolean = false
+    isGemmaModel: boolean = false,
+    apiKey?: string
 ): Promise<string | null> => {
-    if (!API_KEY) {
+    const keyToUse = apiKey || API_KEY;
+    if (!keyToUse) {
         console.error("API_KEY not set for Gemini API for Doctrine selection.");
         return null;
     }
-    const ai = new GoogleGenAI({ apiKey: API_KEY });
+    const ai = new GoogleGenerativeAI(keyToUse);
     const selectedModel = ALLOWED_TEXT_MODELS.includes(modelName) ? modelName : DEFAULT_TEXT_MODEL;
 
     const simplifiedGameState = getSimplifiedGameStateForAI(currentGameState, factionId);

--- a/types.ts
+++ b/types.ts
@@ -227,6 +227,7 @@ export interface GameSettings {
     selectedGenAIModel: string;
     isAggressiveSanitizationEnabled: boolean;
     isStructuredOutputEnabled: boolean; // New setting for toggling structured JSON output
+    apiKey?: string;
 }
 
 export interface SystemLogEntry {


### PR DESCRIPTION
This commit introduces two main features:

1.  **Bring Your Own API Key:**
    - Users can now enter their own Gemini API key in the settings menu.
    - The key is stored in the browser's localStorage and used for all game-related AI API calls, overriding the server's default key.
    - This allows users to use their own quotas and models.

2.  **Model Update:**
    - The list of available generative AI models has been updated.
    - `gemini-2.5-flash` is now the default model for new games.
    - The old `gemini-2.5-flash-preview-04-17` model has been removed.

Backend services and types have been updated to support these changes.